### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,11 @@ If you find this useful, feel free to follow us and star both repos. Thanks to a
 - [TinyStories: How Small Can Language Models Be and Still Speak Coherent English?](https://arxiv.org/abs/2305.07759) *Ronen Eldan, Yuanzhi Li.* Arxiv 2024.
 - [Phi-1: Textbooks Are All You Need](https://arxiv.org/abs/2306.11644) *Suriya Gunasekar, Yi Zhang, Jyoti Aneja, Caio César Teodoro Mendes, Allie Del Giorno, Sivakanth Gopi, Mojan Javaheripi, Piero Kauffmann, Gustavo de Rosa, Olli Saarikivi, Adil Salim, Shital Shah, Harkirat Singh Behl, Xin Wang, Sébastien Bubeck, Ronen Eldan, Adam Tauman Kalai, Yin Tat Lee, Yuanzhi Li.* Arxiv 2023.
 
-### 5.14 Reasonging
+### 5.14 Reasoning
 - [Enhancing Reasoning Capabilities of LLMs via Principled Synthetic Logic Corpus](https://arxiv.org/abs/2411.12498) *Terufumi Morishita, Gaku Morio, Atsuki Yamaguchi, Yasuhiro Sogawa.* NeurIPS 2024
+- [LogicPro: Improving Complex Logical Reasoning via Program-Guided Learning](https://arxiv.org/abs/2409.12929) *Jin Jiang, Yuchen Yan, Yang Liu, Jianing Wang, Shuai Peng, Xunliang Cai, Yixin Cao, Mengdi Zhang, Liangcai Gao.* ACL 2025
+ 
+
 
 ### 6. Tools
 


### PR DESCRIPTION
Add ACL 2025 Main paper "LogicPro: Improving Complex Logical Reasoning via Program-Guided Learning" to the 5.14 Reasoning section.